### PR TITLE
CDPS-1237: Add exception handler for locked downstream resource

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/config/HealthAndMedicationExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/config/HealthAndMedicationExceptionHandler.kt
@@ -241,7 +241,7 @@ class HealthAndMedicationExceptionHandler {
   fun handleDownstreamServiceException(e: DownstreamServiceException): ResponseEntity<ErrorResponse> {
     val cause = e.cause
     return if (cause is WebClientResponseException && cause.statusCode == LOCKED) {
-      log.warn("Resource locked: {}", e.message, e)
+      log.warn("Resource locked: ${e.message}")
       ResponseEntity
         .status(LOCKED)
         .body(


### PR DESCRIPTION
Required by https://dsdmoj.atlassian.net/browse/CDPS-1237

When `DownstreamServiceException` is thrown,  if it happens because of a 423 locked exception, this is propagated so that the calling service can handle this case. Otherwise, the exception is handled as usual. It is also logged as a warning. 