### PR TITLE
CDPS-1988 Implement soft delete

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/jpa/PrisonerHealth.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/jpa/PrisonerHealth.kt
@@ -59,6 +59,15 @@ class PrisonerHealth(
   @OneToMany(mappedBy = "prisonerNumber", fetch = LAZY, cascade = [ALL], orphanRemoval = true)
   @MapKey(name = "field")
   override val fieldMetadata: MutableMap<HealthAndMedicationField, FieldMetadata> = mutableMapOf(),
+
+  @Column(name = "deleted_at")
+  var deletedAt: ZonedDateTime? = null,
+
+  @Column(name = "deleted_by")
+  var deletedBy: String? = null,
+
+  @Column(name = "deletion_reason")
+  var deletionReason: String? = null,
 ) : WithFieldHistory<PrisonerHealth>() {
 
   override fun fieldAccessors(): Map<HealthAndMedicationField, KMutableProperty0<*>> = mapOf(
@@ -151,6 +160,9 @@ class PrisonerHealth(
     if (personalisedDietaryRequirements != other.personalisedDietaryRequirements) return false
     if (cateringInstructions != other.cateringInstructions) return false
     if (location != other.location) return false
+    if (deletedAt != other.deletedAt) return false
+    if (deletedBy != other.deletedBy) return false
+    if (deletionReason != other.deletionReason) return false
 
     return true
   }
@@ -162,6 +174,9 @@ class PrisonerHealth(
     result = 31 * result + personalisedDietaryRequirements.hashCode()
     result = 31 * result + cateringInstructions.hashCode()
     result = 31 * result + location.hashCode()
+    result = 31 * result + deletedAt.hashCode()
+    result = 31 * result + deletedBy.hashCode()
+    result = 31 * result + deletionReason.hashCode()
     return result
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/jpa/repository/PrisonerHealthRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/jpa/repository/PrisonerHealthRepository.kt
@@ -11,6 +11,7 @@ interface PrisonerHealthRepository : JpaRepository<PrisonerHealth, String> {
     """
     SELECT h FROM PrisonerHealth h
     WHERE h.prisonerNumber IN :prisonerNumbers
+    AND h.deletedAt IS NULL
     AND (
         EXISTS (
             SELECT 1 from FoodAllergy fa WHERE fa.prisonerNumber = h.prisonerNumber
@@ -35,6 +36,7 @@ interface PrisonerHealthRepository : JpaRepository<PrisonerHealth, String> {
     """
     SELECT h FROM PrisonerHealth h
     WHERE h.location IS NULL
+    AND h.deletedAt IS NULL
     AND (
         EXISTS (
             SELECT 1 from FoodAllergy fa WHERE fa.prisonerNumber = h.prisonerNumber
@@ -52,4 +54,13 @@ interface PrisonerHealthRepository : JpaRepository<PrisonerHealth, String> {
     """,
   )
   fun findAllPrisonersWithoutLocationData(): List<PrisonerHealth>
+
+  @Query(
+    """
+    SELECT h FROM PrisonerHealth h
+    WHERE h.prisonerNumber = :prisonerNumber
+    AND h.deletedAt IS NULL
+    """,
+  )
+  fun findByPrisonerNumberAndDeletedAtIsNull(prisonerNumber: String): PrisonerHealth?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/PrisonerHealthService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/PrisonerHealthService.kt
@@ -40,7 +40,6 @@ import uk.gov.justice.digital.hmpps.healthandmedication.utils.validatePrisonerNu
 import java.time.Clock
 import java.time.LocalDate
 import java.time.ZonedDateTime
-import kotlin.jvm.optionals.getOrNull
 
 @Service
 @Transactional(readOnly = true)
@@ -54,7 +53,7 @@ class PrisonerHealthService(
   private val authenticationFacade: AuthenticationFacade,
   private val clock: Clock,
 ) {
-  fun getHealth(prisonerNumber: String): HealthAndMedicationResponse? = prisonerHealthRepository.findById(prisonerNumber).getOrNull()?.toHealthDto()
+  fun getHealth(prisonerNumber: String): HealthAndMedicationResponse? = prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(prisonerNumber)?.toHealthDto()
 
   fun getHealthForPrison(
     prisonId: String,
@@ -170,9 +169,7 @@ class PrisonerHealthService(
     val currentLocation = prisonerLocationService.getLatestLocationData(prisonerNumber, usePrisonerSearchOnly = true)
     var changedFields: Collection<HealthAndMedicationField> = emptyList()
 
-    val health = prisonerHealthRepository.findById(prisonerNumber).orElseGet {
-      newHealthFor(prisonerNumber)
-    }.apply {
+    val health = (prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(prisonerNumber) ?: newHealthFor(prisonerNumber)).apply {
       foodAllergies.apply { clear() }.addAll(
         request.foodAllergies!!.map { allergy ->
           FoodAllergy(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/PrisonerHealthService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/PrisonerHealthService.kt
@@ -53,7 +53,9 @@ class PrisonerHealthService(
   private val authenticationFacade: AuthenticationFacade,
   private val clock: Clock,
 ) {
-  fun getHealth(prisonerNumber: String): HealthAndMedicationResponse? = prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(prisonerNumber)?.toHealthDto()
+  fun getHealth(prisonerNumber: String): HealthAndMedicationResponse? = prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(prisonerNumber)
+    ?.takeIf { it.deletedAt == null }
+    ?.toHealthDto()
 
   fun getHealthForPrison(
     prisonId: String,
@@ -80,6 +82,7 @@ class PrisonerHealthService(
 
       // Fetch all non-empty health data for the given prisoner numbers and apply filtering
       val healthData = prisonerHealthRepository.findAllPrisonersWithDietaryNeeds(prisonerNumbers)
+        .filter { it.deletedAt == null }
         .filter { request.filters == null || matchesFilters(it, request.filters, recentArrivalCutoff) }
 
       // This maintains the order from the prisoner search API so that we're able to have sorting
@@ -125,6 +128,7 @@ class PrisonerHealthService(
 
     val prisonerNumbers = prisoners.map { it.prisonerNumber }.toMutableList()
     val healthData = prisonerHealthRepository.findAllPrisonersWithDietaryNeeds(prisonerNumbers)
+      .filter { it.deletedAt == null }
     return buildFiltersResponse(healthData)
   }
 
@@ -134,6 +138,7 @@ class PrisonerHealthService(
 
     val prisonerNumbers = prisoners.map { it.prisonerNumber }.toMutableList()
     val healthData = prisonerHealthRepository.findAllPrisonersWithDietaryNeeds(prisonerNumbers)
+      .filter { it.deletedAt == null }
     val recentArrivalCutoff = LocalDate.now(clock).minusDays(2)
     val filteredHealthData = healthData.filter { matchesFilters(it, filters, recentArrivalCutoff) }
     return buildFiltersResponse(filteredHealthData)
@@ -169,7 +174,7 @@ class PrisonerHealthService(
     val currentLocation = prisonerLocationService.getLatestLocationData(prisonerNumber, usePrisonerSearchOnly = true)
     var changedFields: Collection<HealthAndMedicationField> = emptyList()
 
-    val health = (prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(prisonerNumber) ?: newHealthFor(prisonerNumber)).apply {
+    val health = (prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(prisonerNumber)?.takeIf { it.deletedAt == null } ?: newHealthFor(prisonerNumber)).apply {
       foodAllergies.apply { clear() }.addAll(
         request.foodAllergies!!.map { allergy ->
           FoodAllergy(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/SubjectAccessRequestService.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.healthandmedication.jpa.PersonalisedDietaryR
 import uk.gov.justice.digital.hmpps.healthandmedication.jpa.PersonalisedDietaryRequirementItem
 import uk.gov.justice.digital.hmpps.healthandmedication.jpa.ReferenceDataCode
 import uk.gov.justice.digital.hmpps.healthandmedication.jpa.repository.FieldHistoryRepository
+import uk.gov.justice.digital.hmpps.healthandmedication.jpa.repository.PrisonerHealthRepository
 import uk.gov.justice.digital.hmpps.healthandmedication.jpa.repository.ReferenceDataCodeRepository
 import uk.gov.justice.digital.hmpps.healthandmedication.resource.dto.response.SubjectAccessRequestFieldHistoryType
 import uk.gov.justice.digital.hmpps.healthandmedication.resource.dto.response.SubjectAccessRequestResponseDto
@@ -47,9 +48,13 @@ import java.util.SortedSet
 class SubjectAccessRequestService(
   private val fieldHistoryRepository: FieldHistoryRepository,
   private val referenceDataCodeRepository: ReferenceDataCodeRepository,
+  private val prisonerHealthRepository: PrisonerHealthRepository,
 ) : HmppsPrisonSubjectAccessRequestService {
 
   override fun getPrisonContentFor(prn: String, fromDate: LocalDate?, toDate: LocalDate?): HmppsSubjectAccessRequestContent? {
+    if (prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(prn) == null) {
+      return null
+    }
     try {
       // Check Dates
       //  - Date format in query parameters should be dd/mm/yyyy

--- a/src/main/resources/db/migration/common/V21__add_soft_delete_to_health.sql
+++ b/src/main/resources/db/migration/common/V21__add_soft_delete_to_health.sql
@@ -1,0 +1,9 @@
+-- Add soft delete columns to health table
+ALTER TABLE health ADD COLUMN deleted_at TIMESTAMP WITH TIME ZONE;
+ALTER TABLE health ADD COLUMN deleted_by VARCHAR(100);
+ALTER TABLE health ADD COLUMN deletion_reason TEXT;
+
+-- done as partial index since we expect this to mostly contain nulls
+CREATE INDEX health_deleted_at_idx
+  ON health (deleted_at)
+  WHERE deleted_at IS NOT NULL;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/jpa/repository/PrisonerHealthRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/jpa/repository/PrisonerHealthRepositoryTest.kt
@@ -252,6 +252,51 @@ class PrisonerHealthRepositoryTest : RepositoryTest() {
     assertThat(response.map { it.prisonerNumber }).containsExactlyInAnyOrder("M1111AA", "M2222AA", "M3333AA", "M4444AA")
   }
 
+  @Test
+  fun `soft deleted records are ignored by findAllPrisonersWithDietaryNeeds`() {
+    val health = PrisonerHealth(
+      prisonerNumber = PRISONER_NUMBER,
+      foodAllergies = mutableSetOf(generateAllergy("FOOD_ALLERGY_EGG")),
+    )
+    save(health)
+
+    assertThat(repository.findAllPrisonersWithDietaryNeeds(mutableSetOf(PRISONER_NUMBER))).hasSize(1)
+
+    health.deletedAt = java.time.ZonedDateTime.now()
+    save(health)
+
+    assertThat(repository.findAllPrisonersWithDietaryNeeds(mutableSetOf(PRISONER_NUMBER))).isEmpty()
+  }
+
+  @Test
+  fun `soft deleted records are ignored by findAllPrisonersWithoutLocationData`() {
+    val health = PrisonerHealth(
+      prisonerNumber = PRISONER_NUMBER,
+      foodAllergies = mutableSetOf(generateAllergy("FOOD_ALLERGY_EGG")),
+    )
+    save(health)
+
+    assertThat(repository.findAllPrisonersWithoutLocationData()).extracting("prisonerNumber").contains(PRISONER_NUMBER)
+
+    health.deletedAt = java.time.ZonedDateTime.now()
+    save(health)
+
+    assertThat(repository.findAllPrisonersWithoutLocationData()).extracting("prisonerNumber").doesNotContain(PRISONER_NUMBER)
+  }
+
+  @Test
+  fun `findByPrisonerNumberAndDeletedAtIsNull returns empty for soft deleted record`() {
+    val health = PrisonerHealth(PRISONER_NUMBER)
+    save(health)
+
+    assertThat(repository.findByPrisonerNumberAndDeletedAtIsNull(PRISONER_NUMBER)).isNotNull
+
+    health.deletedAt = java.time.ZonedDateTime.now()
+    save(health)
+
+    assertThat(repository.findByPrisonerNumberAndDeletedAtIsNull(PRISONER_NUMBER)).isNull()
+  }
+
   private fun generateAllergy(id: String, prisonerNumber: String = PRISONER_NUMBER) = FoodAllergy(
     prisonerNumber = prisonerNumber,
     allergy = toReferenceDataCode(referenceDataCodeRepository, id)!!,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/PrisonerHealthServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/PrisonerHealthServiceTest.kt
@@ -136,6 +136,15 @@ class PrisonerHealthServiceTest {
     }
 
     @Test
+    fun `soft deleted health data is not returned`() {
+      whenever(prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(PRISONER_NUMBER)).thenReturn(null)
+
+      val result = underTest.getHealth(PRISONER_NUMBER)
+
+      assertThat(result).isNull()
+    }
+
+    @Test
     fun `prison health data is found`() {
       whenever(prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(PRISONER_NUMBER)).thenReturn(
         PrisonerHealth(
@@ -593,6 +602,17 @@ class PrisonerHealthServiceTest {
             ),
           ),
         )
+      }
+
+      @Test
+      fun `soft deleted records are excluded from the prison health list`() {
+        whenever(prisonerHealthRepository.findAllPrisonersWithDietaryNeeds(mutableListOf(PRISONER_NUMBER, secondPrisonerNumber)))
+          .thenReturn(listOf(secondPrisonerHealth))
+
+        val result = underTest.getHealthForPrison(PRISON_ID, HealthAndMedicationForPrisonRequest(1, 10))
+
+        assertThat(result!!.content).hasSize(1)
+        assertThat(result.content[0].prisonerNumber).isEqualTo(secondPrisonerNumber)
       }
 
       @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/PrisonerHealthServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/PrisonerHealthServiceTest.kt
@@ -129,7 +129,7 @@ class PrisonerHealthServiceTest {
   inner class GetPrisonerHealth {
     @Test
     fun `health data not found`() {
-      whenever(prisonerHealthRepository.findById(PRISONER_NUMBER)).thenReturn(Optional.empty())
+      whenever(prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(PRISONER_NUMBER)).thenReturn(null)
 
       val result = underTest.getHealth(PRISONER_NUMBER)
       assertThat(result).isNull()
@@ -137,36 +137,34 @@ class PrisonerHealthServiceTest {
 
     @Test
     fun `prison health data is found`() {
-      whenever(prisonerHealthRepository.findById(PRISONER_NUMBER)).thenReturn(
-        Optional.of(
-          PrisonerHealth(
-            prisonerNumber = PRISONER_NUMBER,
-            foodAllergies = mutableSetOf(FOOD_ALLERGY_PEANUTS),
-            medicalDietaryRequirements = mutableSetOf(MEDICAL_DIET_COELIAC),
-            personalisedDietaryRequirements = mutableSetOf(PERSONALISED_DIET_VEGAN),
+      whenever(prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(PRISONER_NUMBER)).thenReturn(
+        PrisonerHealth(
+          prisonerNumber = PRISONER_NUMBER,
+          foodAllergies = mutableSetOf(FOOD_ALLERGY_PEANUTS),
+          medicalDietaryRequirements = mutableSetOf(MEDICAL_DIET_COELIAC),
+          personalisedDietaryRequirements = mutableSetOf(PERSONALISED_DIET_VEGAN),
 
-            fieldMetadata = mutableMapOf(
-              FOOD_ALLERGY to FieldMetadata(
-                prisonerNumber = PRISONER_NUMBER,
-                field = FOOD_ALLERGY,
-                lastModifiedAt = NOW,
-                lastModifiedBy = USER1,
-                lastModifiedPrisonId = "STI",
-              ),
-              MEDICAL_DIET to FieldMetadata(
-                prisonerNumber = PRISONER_NUMBER,
-                field = MEDICAL_DIET,
-                lastModifiedAt = NOW,
-                lastModifiedBy = USER1,
-                lastModifiedPrisonId = "STI",
-              ),
-              PERSONALISED_DIET to FieldMetadata(
-                prisonerNumber = PRISONER_NUMBER,
-                field = PERSONALISED_DIET,
-                lastModifiedAt = NOW,
-                lastModifiedBy = USER1,
-                lastModifiedPrisonId = "STI",
-              ),
+          fieldMetadata = mutableMapOf(
+            FOOD_ALLERGY to FieldMetadata(
+              prisonerNumber = PRISONER_NUMBER,
+              field = FOOD_ALLERGY,
+              lastModifiedAt = NOW,
+              lastModifiedBy = USER1,
+              lastModifiedPrisonId = "STI",
+            ),
+            MEDICAL_DIET to FieldMetadata(
+              prisonerNumber = PRISONER_NUMBER,
+              field = MEDICAL_DIET,
+              lastModifiedAt = NOW,
+              lastModifiedBy = USER1,
+              lastModifiedPrisonId = "STI",
+            ),
+            PERSONALISED_DIET to FieldMetadata(
+              prisonerNumber = PRISONER_NUMBER,
+              field = PERSONALISED_DIET,
+              lastModifiedAt = NOW,
+              lastModifiedBy = USER1,
+              lastModifiedPrisonId = "STI",
             ),
           ),
         ),
@@ -239,7 +237,7 @@ class PrisonerHealthServiceTest {
       whenever(prisonerSearchClient.getPrisoner(PRISONER_NUMBER))
         .thenReturn(PRISONER_SEARCH_RESPONSE)
 
-      whenever(prisonerHealthRepository.findById(PRISONER_NUMBER)).thenReturn(Optional.empty())
+      whenever(prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(PRISONER_NUMBER)).thenReturn(null)
 
       assertThat(
         underTest.updateDietAndAllergyData(
@@ -332,23 +330,21 @@ class PrisonerHealthServiceTest {
       whenever(prisonerSearchClient.getPrisoner(PRISONER_NUMBER))
         .thenReturn(PRISONER_SEARCH_RESPONSE)
 
-      whenever(prisonerHealthRepository.findById(PRISONER_NUMBER)).thenReturn(
-        Optional.of(
-          PrisonerHealth(
-            prisonerNumber = PRISONER_NUMBER,
-            foodAllergies = mutableSetOf(FOOD_ALLERGY_PEANUTS),
-            medicalDietaryRequirements = mutableSetOf(MEDICAL_DIET_COELIAC),
-            personalisedDietaryRequirements = mutableSetOf(PERSONALISED_DIET_VEGAN),
-            cateringInstructions = CateringInstructions(PRISONER_NUMBER, "outdated instructions"),
-            location = null,
-          ).also {
-            it.updateFieldHistory(
-              lastModifiedAt = NOW.minusDays(1),
-              lastModifiedBy = USER2,
-              lastModifiedPrisonId = "KMI",
-            )
-          },
-        ),
+      whenever(prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(PRISONER_NUMBER)).thenReturn(
+        PrisonerHealth(
+          prisonerNumber = PRISONER_NUMBER,
+          foodAllergies = mutableSetOf(FOOD_ALLERGY_PEANUTS),
+          medicalDietaryRequirements = mutableSetOf(MEDICAL_DIET_COELIAC),
+          personalisedDietaryRequirements = mutableSetOf(PERSONALISED_DIET_VEGAN),
+          cateringInstructions = CateringInstructions(PRISONER_NUMBER, "outdated instructions"),
+          location = null,
+        ).also {
+          it.updateFieldHistory(
+            lastModifiedAt = NOW.minusDays(1),
+            lastModifiedBy = USER2,
+            lastModifiedPrisonId = "KMI",
+          )
+        },
       )
 
       assertThat(underTest.updateDietAndAllergyData(PRISONER_NUMBER, EMPTY_DIET_AND_ALLERGY_UPDATE_REQUEST)).isEqualTo(
@@ -438,23 +434,21 @@ class PrisonerHealthServiceTest {
 
     @Test
     fun `no events are published when diet and allergy data is unchanged`() {
-      whenever(prisonerHealthRepository.findById(PRISONER_NUMBER)).thenReturn(
-        Optional.of(
-          PrisonerHealth(
-            prisonerNumber = PRISONER_NUMBER,
-            foodAllergies = mutableSetOf(FOOD_ALLERGY_PEANUTS),
-            medicalDietaryRequirements = mutableSetOf(MEDICAL_DIET_COELIAC),
-            personalisedDietaryRequirements = mutableSetOf(PERSONALISED_DIET_VEGAN),
-            cateringInstructions = CateringInstructions(PRISONER_NUMBER, "Some catering instructions."),
-            location = null,
-          ).also {
-            it.updateFieldHistory(
-              lastModifiedAt = NOW.minusDays(1),
-              lastModifiedBy = USER2,
-              lastModifiedPrisonId = "KMI",
-            )
-          },
-        ),
+      whenever(prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(PRISONER_NUMBER)).thenReturn(
+        PrisonerHealth(
+          prisonerNumber = PRISONER_NUMBER,
+          foodAllergies = mutableSetOf(FOOD_ALLERGY_PEANUTS),
+          medicalDietaryRequirements = mutableSetOf(MEDICAL_DIET_COELIAC),
+          personalisedDietaryRequirements = mutableSetOf(PERSONALISED_DIET_VEGAN),
+          cateringInstructions = CateringInstructions(PRISONER_NUMBER, "Some catering instructions."),
+          location = null,
+        ).also {
+          it.updateFieldHistory(
+            lastModifiedAt = NOW.minusDays(1),
+            lastModifiedBy = USER2,
+            lastModifiedPrisonId = "KMI",
+          )
+        },
       )
 
       underTest.updateDietAndAllergyData(PRISONER_NUMBER, DIET_AND_ALLERGY_UPDATE_REQUEST)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/PrisonerHealthServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/PrisonerHealthServiceTest.kt
@@ -137,11 +137,18 @@ class PrisonerHealthServiceTest {
 
     @Test
     fun `soft deleted health data is not returned`() {
-      whenever(prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(PRISONER_NUMBER)).thenReturn(null)
+      val softDeletedPrisonerHealthRecord = PrisonerHealth(
+        prisonerNumber = PRISONER_NUMBER,
+        deletedAt = NOW,
+        deletedBy = USER1,
+        deletionReason = "Record merged",
+      )
+      whenever(prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(PRISONER_NUMBER)).thenReturn(softDeletedPrisonerHealthRecord)
 
       val result = underTest.getHealth(PRISONER_NUMBER)
 
       assertThat(result).isNull()
+      verify(prisonerHealthRepository).findByPrisonerNumberAndDeletedAtIsNull(PRISONER_NUMBER)
     }
 
     @Test
@@ -527,6 +534,12 @@ class PrisonerHealthServiceTest {
           lastAdmissionDate = RECENT_ADMISSION,
         ),
       )
+      private val softDeletedPrisonerHealthRecord = PrisonerHealth(
+        prisonerNumber = PRISONER_NUMBER,
+        deletedAt = NOW,
+        deletedBy = USER1,
+        deletionReason = "Record merged",
+      )
 
       private val firstPrisonerHealthResponse = HealthAndMedicationForPrisonDto(
         prisonerNumber = PRISONER_NUMBER,
@@ -607,7 +620,7 @@ class PrisonerHealthServiceTest {
       @Test
       fun `soft deleted records are excluded from the prison health list`() {
         whenever(prisonerHealthRepository.findAllPrisonersWithDietaryNeeds(mutableListOf(PRISONER_NUMBER, secondPrisonerNumber)))
-          .thenReturn(listOf(secondPrisonerHealth))
+          .thenReturn(listOf(softDeletedPrisonerHealthRecord, secondPrisonerHealth))
 
         val result = underTest.getHealthForPrison(PRISON_ID, HealthAndMedicationForPrisonRequest(1, 10))
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/SubjectAccessRequestServiceTest.kt
@@ -23,9 +23,11 @@ import uk.gov.justice.digital.hmpps.healthandmedication.jpa.MedicalDietaryRequir
 import uk.gov.justice.digital.hmpps.healthandmedication.jpa.MedicalDietaryRequirementItem
 import uk.gov.justice.digital.hmpps.healthandmedication.jpa.PersonalisedDietaryRequirementHistory
 import uk.gov.justice.digital.hmpps.healthandmedication.jpa.PersonalisedDietaryRequirementItem
+import uk.gov.justice.digital.hmpps.healthandmedication.jpa.PrisonerHealth
 import uk.gov.justice.digital.hmpps.healthandmedication.jpa.ReferenceDataCode
 import uk.gov.justice.digital.hmpps.healthandmedication.jpa.ReferenceDataDomain
 import uk.gov.justice.digital.hmpps.healthandmedication.jpa.repository.FieldHistoryRepository
+import uk.gov.justice.digital.hmpps.healthandmedication.jpa.repository.PrisonerHealthRepository
 import uk.gov.justice.digital.hmpps.healthandmedication.jpa.repository.ReferenceDataCodeRepository
 import uk.gov.justice.digital.hmpps.healthandmedication.resource.dto.response.SubjectAccessRequestFieldHistoryType
 import uk.gov.justice.digital.hmpps.healthandmedication.resource.dto.response.SubjectAccessRequestResponseDto
@@ -46,11 +48,15 @@ class SubjectAccessRequestServiceTest {
   @Mock
   lateinit var fieldHistoryRepository: FieldHistoryRepository
 
+  @Mock
+  lateinit var prisonerHealthRepository: PrisonerHealthRepository
+
   @InjectMocks
   private lateinit var subjectaccessRequestService: SubjectAccessRequestService
 
   @Test
   fun `can retrieve ordered SAR data for a prisoner when data is between two dates`() {
+    whenever(prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(PRISONER_NUMBER)).thenReturn(PrisonerHealth(PRISONER_NUMBER))
     val queryFrom = ZonedDateTime.of(2025, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault())
     val queryTo = ZonedDateTime.of(2025, 1, 4, 23, 59, 59, 999999999, ZoneId.systemDefault())
 
@@ -177,6 +183,7 @@ class SubjectAccessRequestServiceTest {
 
   @Test
   fun `can retrieve ordered SAR data for a prisoner when data is partially before two dates`() {
+    whenever(prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(PRISONER_NUMBER)).thenReturn(PrisonerHealth(PRISONER_NUMBER))
     val queryFrom = ZonedDateTime.of(2025, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault())
     val queryTo = ZonedDateTime.of(2025, 1, 4, 23, 59, 59, 999999999, ZoneId.systemDefault())
 
@@ -324,6 +331,7 @@ class SubjectAccessRequestServiceTest {
 
   @Test
   fun `can retrieve ordered SAR data for a prisoner when data is completely before two dates`() {
+    whenever(prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(PRISONER_NUMBER)).thenReturn(PrisonerHealth(PRISONER_NUMBER))
     val queryFrom = ZonedDateTime.of(2025, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault())
     val queryTo = ZonedDateTime.of(2025, 1, 4, 23, 59, 59, 999999999, ZoneId.systemDefault())
 
@@ -450,6 +458,7 @@ class SubjectAccessRequestServiceTest {
 
   @Test
   fun `no data for a prisoner between two dates`() {
+    whenever(prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(PRISONER_NUMBER)).thenReturn(PrisonerHealth(PRISONER_NUMBER))
     val queryFrom = ZonedDateTime.of(2025, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault())
     val queryTo = ZonedDateTime.of(2025, 1, 4, 23, 59, 59, 999999999, ZoneId.systemDefault())
 
@@ -467,10 +476,7 @@ class SubjectAccessRequestServiceTest {
 
   @Test
   fun `prisoner not found`() {
-    val queryFrom = ZonedDateTime.of(2025, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault())
-    val queryTo = ZonedDateTime.of(2025, 1, 4, 23, 59, 59, 999999999, ZoneId.systemDefault())
-
-    whenever(fieldHistoryRepository.findAllByPrisonerNumberAndCreatedAtBetweenOrderByFieldHistoryIdDesc(PRISONER_NUMBER, queryFrom, queryTo)).thenReturn(null)
+    whenever(prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(UNKNOWN_PRISONER_NUMBER)).thenReturn(null)
 
     val fromDate: LocalDate = LocalDate.parse("2025-01-01")
     val toDate: LocalDate = LocalDate.parse("2025-01-04")
@@ -478,12 +484,24 @@ class SubjectAccessRequestServiceTest {
     val result: HmppsSubjectAccessRequestContent? = subjectaccessRequestService.getPrisonContentFor(UNKNOWN_PRISONER_NUMBER, fromDate, toDate)
 
     assertThat(result).isNull()
+  }
 
-    verify(fieldHistoryRepository).findAllByPrisonerNumberAndCreatedAtBetweenOrderByFieldHistoryIdDesc(UNKNOWN_PRISONER_NUMBER, queryFrom, queryTo)
+  @Test
+  fun `soft deleted prisoner returns null`() {
+    val deletedPrisoner = PrisonerHealth(PRISONER_NUMBER).apply { deletedAt = NOW }
+    whenever(prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(PRISONER_NUMBER)).thenReturn(null)
+
+    val fromDate: LocalDate = LocalDate.parse("2025-01-01")
+    val toDate: LocalDate = LocalDate.parse("2025-01-04")
+
+    val result: HmppsSubjectAccessRequestContent? = subjectaccessRequestService.getPrisonContentFor(PRISONER_NUMBER, fromDate, toDate)
+
+    assertThat(result).isNull()
   }
 
   @Test
   fun `null start date and null end date converted into 1970-01-01 00h 00m 00s and 3000-01-01 23h 59m 59s when querying data`() {
+    whenever(prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(PRISONER_NUMBER)).thenReturn(PrisonerHealth(PRISONER_NUMBER))
     val queryFrom = ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault())
     val queryTo = ZonedDateTime.of(3000, 1, 1, 23, 59, 59, 999999999, ZoneId.systemDefault())
 
@@ -501,6 +519,7 @@ class SubjectAccessRequestServiceTest {
 
   @Test
   fun `can tolerate misformed SAR data for a prisoner between two dates`() {
+    whenever(prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(PRISONER_NUMBER)).thenReturn(PrisonerHealth(PRISONER_NUMBER))
     val queryFrom = ZonedDateTime.of(2025, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault())
     val queryTo = ZonedDateTime.of(2025, 1, 4, 23, 59, 59, 999999999, ZoneId.systemDefault())
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -33,7 +33,7 @@ hmpps:
   sar:
     tests:
       attachments-expected: false
-      expected-flyway-schema-version: 20
+      expected-flyway-schema-version: 21
       expected-jpa-entity-schema:
         path: /sar/entity-schema.json
       expected-api-response:

--- a/src/test/resources/sar/entity-schema.json
+++ b/src/test/resources/sar/entity-schema.json
@@ -44,6 +44,9 @@
   },
   "PrisonerHealth": {
     "cateringInstructions": "CateringInstructions",
+    "deletedAt": "ZonedDateTime",
+    "deletedBy": "String",
+    "deletionReason": "String",
     "fieldHistory": "SortedSet",
     "fieldMetadata": "Map",
     "foodAllergies": "Set",


### PR DESCRIPTION
This PR implements soft deletion, via three new fields, to the Health and Medication API's `health` table and corresponding `PrisonerHealth` entity - `deletedAt`, `deletedBy`, and `deletedReason`.

See [CDPS-1988](https://dsdmoj.atlassian.net/jira/software/c/projects/CDPS/boards/1118?label=Squad_2%2CSupport_Rota_Task&selectedIssue=CDPS-1988) for further information.

[CDPS-1988]: https://dsdmoj.atlassian.net/browse/CDPS-1988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ