### PR TITLE
CDPS-1989 Implement pending merge scaffolding

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/jpa/PrisonerHealth.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/jpa/PrisonerHealth.kt
@@ -11,6 +11,8 @@ import jakarta.persistence.OneToMany
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import org.hibernate.Hibernate
+import org.hibernate.annotations.BatchSize
+import org.hibernate.annotations.SQLRestriction
 import org.hibernate.annotations.SortNatural
 import uk.gov.justice.digital.hmpps.healthandmedication.enums.HealthAndMedicationField
 import uk.gov.justice.digital.hmpps.healthandmedication.enums.HealthAndMedicationField.CATERING_INSTRUCTIONS
@@ -68,6 +70,20 @@ class PrisonerHealth(
 
   @Column(name = "deletion_reason")
   var deletionReason: String? = null,
+
+  @Column(name = "pending_merge_to_prisoner_number")
+  var pendingMergeToPrisonerNumber: String? = null,
+
+  @OneToMany(fetch = LAZY)
+  @JoinColumn(
+    name = "pending_merge_to_prisoner_number",
+    referencedColumnName = "prisoner_number",
+    insertable = false,
+    updatable = false,
+  )
+  @SQLRestriction("deleted_at IS NULL")
+  @BatchSize(size = 25)
+  var pendingMerges: MutableSet<PrisonerHealth> = mutableSetOf(),
 ) : WithFieldHistory<PrisonerHealth>() {
 
   override fun fieldAccessors(): Map<HealthAndMedicationField, KMutableProperty0<*>> = mapOf(
@@ -77,7 +93,21 @@ class PrisonerHealth(
     CATERING_INSTRUCTIONS to ::cateringInstructions,
   )
 
-  fun toHealthDto(): HealthAndMedicationResponse = HealthAndMedicationResponse(toDietAndAllergyDto())
+  fun toHealthDto(includePendingMerges: Boolean = true): HealthAndMedicationResponse = HealthAndMedicationResponse(
+    dietAndAllergy = toDietAndAllergyDto(),
+    pendingMerges = if (includePendingMerges) {
+      pendingMerges
+        .filter { pending ->
+          pending.foodAllergies.isNotEmpty() ||
+            pending.medicalDietaryRequirements.isNotEmpty() ||
+            pending.personalisedDietaryRequirements.isNotEmpty() ||
+            (pending.cateringInstructions?.instructions?.isNotBlank() == true)
+        }
+        .map { it.toHealthDto(false) }
+    } else {
+      emptyList()
+    },
+  )
 
   fun toDietAndAllergyDto(): DietAndAllergyResponse = DietAndAllergyResponse(
     foodAllergies = getReferenceDataListValueWithMetadata(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/jpa/repository/PrisonerHealthRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/jpa/repository/PrisonerHealthRepository.kt
@@ -12,19 +12,22 @@ interface PrisonerHealthRepository : JpaRepository<PrisonerHealth, String> {
     SELECT h FROM PrisonerHealth h
     WHERE h.prisonerNumber IN :prisonerNumbers
     AND h.deletedAt IS NULL
+    AND h.pendingMergeToPrisonerNumber IS NULL
     AND (
-        EXISTS (
-            SELECT 1 from FoodAllergy fa WHERE fa.prisonerNumber = h.prisonerNumber
+      EXISTS (SELECT 1 FROM FoodAllergy fa WHERE fa.prisonerNumber = h.prisonerNumber)
+      OR EXISTS (SELECT 1 FROM MedicalDietaryRequirement mdr WHERE mdr.prisonerNumber = h.prisonerNumber)
+      OR EXISTS (SELECT 1 FROM PersonalisedDietaryRequirement pdr WHERE pdr.prisonerNumber = h.prisonerNumber)
+      OR EXISTS (SELECT 1 FROM CateringInstructions ci WHERE ci.prisonerNumber = h.prisonerNumber)
+      OR EXISTS (
+        SELECT 1 FROM PrisonerHealth ph WHERE ph.pendingMergeToPrisonerNumber = h.prisonerNumber
+        AND ph.deletedAt IS NULL
+        AND (
+          EXISTS (SELECT 1 FROM FoodAllergy fa WHERE fa.prisonerNumber = ph.prisonerNumber)
+          OR EXISTS (SELECT 1 FROM MedicalDietaryRequirement mdr WHERE mdr.prisonerNumber = ph.prisonerNumber)
+          OR EXISTS (SELECT 1 FROM PersonalisedDietaryRequirement pdr WHERE pdr.prisonerNumber = ph.prisonerNumber)
+          OR EXISTS (SELECT 1 FROM CateringInstructions ci WHERE ci.prisonerNumber = ph.prisonerNumber)
         )
-        OR EXISTS (
-            SELECT 1 from MedicalDietaryRequirement mdr WHERE mdr.prisonerNumber = h.prisonerNumber
-        )
-        OR EXISTS (
-            SELECT 1 from PersonalisedDietaryRequirement pdr WHERE pdr.prisonerNumber = h.prisonerNumber
-        )
-        OR EXISTS (
-            SELECT 1 from CateringInstructions ci WHERE ci.prisonerNumber = h.prisonerNumber
-        )
+      )
     )
     """,
   )
@@ -37,19 +40,22 @@ interface PrisonerHealthRepository : JpaRepository<PrisonerHealth, String> {
     SELECT h FROM PrisonerHealth h
     WHERE h.location IS NULL
     AND h.deletedAt IS NULL
+    AND h.pendingMergeToPrisonerNumber IS NULL
     AND (
-        EXISTS (
-            SELECT 1 from FoodAllergy fa WHERE fa.prisonerNumber = h.prisonerNumber
+      EXISTS (SELECT 1 FROM FoodAllergy fa WHERE fa.prisonerNumber = h.prisonerNumber)
+      OR EXISTS (SELECT 1 FROM MedicalDietaryRequirement mdr WHERE mdr.prisonerNumber = h.prisonerNumber)
+      OR EXISTS (SELECT 1 FROM PersonalisedDietaryRequirement pdr WHERE pdr.prisonerNumber = h.prisonerNumber)
+      OR EXISTS (SELECT 1 FROM CateringInstructions ci WHERE ci.prisonerNumber = h.prisonerNumber)
+      OR EXISTS (
+        SELECT 1 FROM PrisonerHealth ph WHERE ph.pendingMergeToPrisonerNumber = h.prisonerNumber
+        AND ph.deletedAt IS NULL
+        AND (
+          EXISTS (SELECT 1 FROM FoodAllergy fa WHERE fa.prisonerNumber = ph.prisonerNumber)
+          OR EXISTS (SELECT 1 FROM MedicalDietaryRequirement mdr WHERE mdr.prisonerNumber = ph.prisonerNumber)
+          OR EXISTS (SELECT 1 FROM PersonalisedDietaryRequirement pdr WHERE pdr.prisonerNumber = ph.prisonerNumber)
+          OR EXISTS (SELECT 1 FROM CateringInstructions ci WHERE ci.prisonerNumber = ph.prisonerNumber)
         )
-        OR EXISTS (
-            SELECT 1 from MedicalDietaryRequirement mdr WHERE mdr.prisonerNumber = h.prisonerNumber
-        )
-        OR EXISTS (
-            SELECT 1 from PersonalisedDietaryRequirement pdr WHERE pdr.prisonerNumber = h.prisonerNumber
-        )
-        OR EXISTS (
-            SELECT 1 from CateringInstructions ci WHERE ci.prisonerNumber = h.prisonerNumber
-        )
+      )
     )
     """,
   )
@@ -63,4 +69,13 @@ interface PrisonerHealthRepository : JpaRepository<PrisonerHealth, String> {
     """,
   )
   fun findByPrisonerNumberAndDeletedAtIsNull(prisonerNumber: String): PrisonerHealth?
+
+  @Query(
+    """
+    SELECT h FROM PrisonerHealth h
+    WHERE h.prisonerNumber = :prisonerNumber
+    AND h.deletedAt IS NOT NULL
+    """,
+  )
+  fun findByPrisonerNumberAndDeletedAtIsNotNull(prisonerNumber: String): PrisonerHealth?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/resource/dto/response/HealthAndMedicationForPrisonResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/resource/dto/response/HealthAndMedicationForPrisonResponse.kt
@@ -8,6 +8,7 @@ data class HealthAndMedicationForPrisonDto(
   val lastName: String?,
   val location: String?,
   val health: HealthAndMedicationResponse,
+  val pendingMerges: List<HealthAndMedicationForPrisonDto> = emptyList(),
 )
 
 data class HealthAndMedicationForPrisonResponse(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/resource/dto/response/HealthAndMedicationResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/resource/dto/response/HealthAndMedicationResponse.kt
@@ -6,4 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class HealthAndMedicationResponse(
   @Schema(description = "Diet and allergy")
   val dietAndAllergy: DietAndAllergyResponse? = null,
+
+  @Schema(description = "Pending merges")
+  val pendingMerges: List<HealthAndMedicationResponse> = emptyList(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/PrisonerHealthService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/PrisonerHealthService.kt
@@ -97,7 +97,24 @@ class PrisonerHealthService(
               lastName = prisoner.lastName,
               location = prisoner.cellLocation,
               prisonerNumber = prisonerNumber,
-              health = health.toHealthDto(),
+              health = health.toHealthDto(includePendingMerges = false),
+              pendingMerges = health.pendingMerges
+                .filter { pending ->
+                  pending.foodAllergies.isNotEmpty() ||
+                    pending.medicalDietaryRequirements.isNotEmpty() ||
+                    pending.personalisedDietaryRequirements.isNotEmpty() ||
+                    (pending.cateringInstructions?.instructions?.isNotBlank() == true)
+                }
+                .map { pending ->
+                  val pendingPrisoner = prisoners.find { it.prisonerNumber == pending.prisonerNumber }
+                  HealthAndMedicationForPrisonDto(
+                    firstName = pendingPrisoner?.firstName,
+                    lastName = pendingPrisoner?.lastName,
+                    location = pendingPrisoner?.cellLocation,
+                    prisonerNumber = pending.prisonerNumber,
+                    health = pending.toHealthDto(includePendingMerges = false),
+                  )
+                },
             )
           }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/PrisonerHealthService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/PrisonerHealthService.kt
@@ -53,9 +53,7 @@ class PrisonerHealthService(
   private val authenticationFacade: AuthenticationFacade,
   private val clock: Clock,
 ) {
-  fun getHealth(prisonerNumber: String): HealthAndMedicationResponse? = prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(prisonerNumber)
-    ?.takeIf { it.deletedAt == null }
-    ?.toHealthDto()
+  fun getHealth(prisonerNumber: String): HealthAndMedicationResponse? = prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(prisonerNumber)?.toHealthDto()
 
   fun getHealthForPrison(
     prisonId: String,
@@ -82,7 +80,6 @@ class PrisonerHealthService(
 
       // Fetch all non-empty health data for the given prisoner numbers and apply filtering
       val healthData = prisonerHealthRepository.findAllPrisonersWithDietaryNeeds(prisonerNumbers)
-        .filter { it.deletedAt == null }
         .filter { request.filters == null || matchesFilters(it, request.filters, recentArrivalCutoff) }
 
       // This maintains the order from the prisoner search API so that we're able to have sorting
@@ -128,7 +125,6 @@ class PrisonerHealthService(
 
     val prisonerNumbers = prisoners.map { it.prisonerNumber }.toMutableList()
     val healthData = prisonerHealthRepository.findAllPrisonersWithDietaryNeeds(prisonerNumbers)
-      .filter { it.deletedAt == null }
     return buildFiltersResponse(healthData)
   }
 
@@ -138,7 +134,6 @@ class PrisonerHealthService(
 
     val prisonerNumbers = prisoners.map { it.prisonerNumber }.toMutableList()
     val healthData = prisonerHealthRepository.findAllPrisonersWithDietaryNeeds(prisonerNumbers)
-      .filter { it.deletedAt == null }
     val recentArrivalCutoff = LocalDate.now(clock).minusDays(2)
     val filteredHealthData = healthData.filter { matchesFilters(it, filters, recentArrivalCutoff) }
     return buildFiltersResponse(filteredHealthData)
@@ -174,7 +169,7 @@ class PrisonerHealthService(
     val currentLocation = prisonerLocationService.getLatestLocationData(prisonerNumber, usePrisonerSearchOnly = true)
     var changedFields: Collection<HealthAndMedicationField> = emptyList()
 
-    val health = (prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(prisonerNumber)?.takeIf { it.deletedAt == null } ?: newHealthFor(prisonerNumber)).apply {
+    val health = (prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(prisonerNumber) ?: newHealthFor(prisonerNumber)).apply {
       foodAllergies.apply { clear() }.addAll(
         request.foodAllergies!!.map { allergy ->
           FoodAllergy(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/PrisonerHealthService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/PrisonerHealthService.kt
@@ -53,7 +53,9 @@ class PrisonerHealthService(
   private val authenticationFacade: AuthenticationFacade,
   private val clock: Clock,
 ) {
-  fun getHealth(prisonerNumber: String): HealthAndMedicationResponse? = prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(prisonerNumber)?.toHealthDto()
+  fun getHealth(prisonerNumber: String): HealthAndMedicationResponse? = prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(prisonerNumber)
+    ?.takeIf { it.deletedAt == null }
+    ?.toHealthDto()
 
   fun getHealthForPrison(
     prisonId: String,
@@ -80,6 +82,7 @@ class PrisonerHealthService(
 
       // Fetch all non-empty health data for the given prisoner numbers and apply filtering
       val healthData = prisonerHealthRepository.findAllPrisonersWithDietaryNeeds(prisonerNumbers)
+        .filter { it.deletedAt == null }
         .filter { request.filters == null || matchesFilters(it, request.filters, recentArrivalCutoff) }
 
       // This maintains the order from the prisoner search API so that we're able to have sorting
@@ -125,6 +128,7 @@ class PrisonerHealthService(
 
     val prisonerNumbers = prisoners.map { it.prisonerNumber }.toMutableList()
     val healthData = prisonerHealthRepository.findAllPrisonersWithDietaryNeeds(prisonerNumbers)
+      .filter { it.deletedAt == null }
     return buildFiltersResponse(healthData)
   }
 
@@ -134,6 +138,7 @@ class PrisonerHealthService(
 
     val prisonerNumbers = prisoners.map { it.prisonerNumber }.toMutableList()
     val healthData = prisonerHealthRepository.findAllPrisonersWithDietaryNeeds(prisonerNumbers)
+      .filter { it.deletedAt == null }
     val recentArrivalCutoff = LocalDate.now(clock).minusDays(2)
     val filteredHealthData = healthData.filter { matchesFilters(it, filters, recentArrivalCutoff) }
     return buildFiltersResponse(filteredHealthData)
@@ -169,7 +174,7 @@ class PrisonerHealthService(
     val currentLocation = prisonerLocationService.getLatestLocationData(prisonerNumber, usePrisonerSearchOnly = true)
     var changedFields: Collection<HealthAndMedicationField> = emptyList()
 
-    val health = (prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(prisonerNumber) ?: newHealthFor(prisonerNumber)).apply {
+    val health = (prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(prisonerNumber)?.takeIf { it.deletedAt == null } ?: newHealthFor(prisonerNumber)).apply {
       foodAllergies.apply { clear() }.addAll(
         request.foodAllergies!!.map { allergy ->
           FoodAllergy(

--- a/src/main/resources/db/migration/common/V22__add-pending-merge-column-to-health.sql
+++ b/src/main/resources/db/migration/common/V22__add-pending-merge-column-to-health.sql
@@ -1,0 +1,7 @@
+-- add pending merge column to health table
+ALTER TABLE health ADD COLUMN pending_merge_to_prisoner_number VARCHAR(7);
+
+-- done as partial index since we expect this to mostly contain nulls
+CREATE INDEX health_pending_merge_to_prisoner_number_idx
+    ON health (pending_merge_to_prisoner_number)
+    WHERE pending_merge_to_prisoner_number IS NOT NULL;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/jpa/repository/PrisonerHealthRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/jpa/repository/PrisonerHealthRepositoryTest.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.healthandmedication.jpa.repository
 
+import jakarta.persistence.EntityManager
 import org.assertj.core.api.Assertions.assertThat
+import org.hibernate.Session
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.transaction.TestTransaction
@@ -16,6 +18,9 @@ class PrisonerHealthRepositoryTest : RepositoryTest() {
 
   @Autowired
   lateinit var repository: PrisonerHealthRepository
+
+  @Autowired
+  lateinit var entityManager: EntityManager
 
   @Autowired
   lateinit var referenceDataCodeRepository: ReferenceDataCodeRepository
@@ -296,6 +301,136 @@ class PrisonerHealthRepositoryTest : RepositoryTest() {
 
     assertThat(repository.findByPrisonerNumberAndDeletedAtIsNull(PRISONER_NUMBER)).isNull()
   }
+
+  @Test
+  fun `findAllPrisonersWithDietaryNeeds includes records with pending merges and filters top level only`() {
+    val pendingPrisonerNumber = "B1234PN"
+    val pendingRecord = createHealthWithAllergy(pendingPrisonerNumber, "FOOD_ALLERGY_PEANUTS")
+    pendingRecord.pendingMergeToPrisonerNumber = PRISONER_NUMBER
+
+    val mainRecord = PrisonerHealth(PRISONER_NUMBER)
+    save(mainRecord)
+    save(pendingRecord)
+
+    val result = repository.findAllPrisonersWithDietaryNeeds(mutableSetOf(PRISONER_NUMBER, pendingPrisonerNumber))
+    // Should return the main record because it has a pending merge with data
+    assertThat(result).hasSize(1)
+    assertThat(result[0].prisonerNumber).isEqualTo(PRISONER_NUMBER)
+    assertThat(result[0].pendingMerges).hasSize(1)
+  }
+
+  @Test
+  fun `findAllPrisonersWithDietaryNeeds excludes blank records with only blank pending merges`() {
+    val pendingPrisonerNumber = "B1234PN"
+    val pendingRecord = PrisonerHealth(pendingPrisonerNumber)
+    pendingRecord.pendingMergeToPrisonerNumber = PRISONER_NUMBER
+
+    val mainRecord = PrisonerHealth(PRISONER_NUMBER)
+    save(mainRecord)
+    save(pendingRecord)
+
+    val result = repository.findAllPrisonersWithDietaryNeeds(mutableSetOf(PRISONER_NUMBER, pendingPrisonerNumber))
+    // Both are blank, so main record should not be returned
+    assertThat(result).isEmpty()
+  }
+
+  @Test
+  fun `findAllPrisonersWithDietaryNeeds does not return soft deleted main record even with active pending merges`() {
+    val pendingPrisonerNumber = "B1234PN"
+    val pendingRecord = createHealthWithAllergy(pendingPrisonerNumber, "FOOD_ALLERGY_PEANUTS")
+    pendingRecord.pendingMergeToPrisonerNumber = PRISONER_NUMBER
+
+    val mainRecord = createHealthWithAllergy(PRISONER_NUMBER, "FOOD_ALLERGY_EGG")
+    mainRecord.deletedAt = java.time.ZonedDateTime.now()
+
+    save(mainRecord)
+    save(pendingRecord)
+
+    val result = repository.findAllPrisonersWithDietaryNeeds(mutableSetOf(PRISONER_NUMBER, pendingPrisonerNumber))
+    // Main record is soft-deleted, so it should not be returned at all
+    assertThat(result).isEmpty()
+  }
+
+  @Test
+  fun `findAllPrisonersWithDietaryNeeds ignores soft deleted pending merges`() {
+    val pendingPrisonerNumber = "B1234PN"
+    val pendingRecord = createHealthWithAllergy(pendingPrisonerNumber, "FOOD_ALLERGY_PEANUTS")
+    pendingRecord.pendingMergeToPrisonerNumber = PRISONER_NUMBER
+    pendingRecord.deletedAt = java.time.ZonedDateTime.now()
+
+    val mainRecord = PrisonerHealth(PRISONER_NUMBER)
+    save(mainRecord)
+    save(pendingRecord)
+
+    val result = repository.findAllPrisonersWithDietaryNeeds(mutableSetOf(PRISONER_NUMBER, pendingPrisonerNumber))
+    // Main record is blank and its only pending merge is soft-deleted
+    assertThat(result).isEmpty()
+  }
+
+  @Test
+  fun `pendingMerges collection filters out soft deleted records`() {
+    val pendingPrisonerNumber = "B1234PN"
+    val pendingRecord = PrisonerHealth(
+      prisonerNumber = pendingPrisonerNumber,
+      foodAllergies = mutableSetOf(generateAllergy("FOOD_ALLERGY_PEANUTS", pendingPrisonerNumber)),
+      pendingMergeToPrisonerNumber = PRISONER_NUMBER,
+      deletedAt = java.time.ZonedDateTime.now(),
+    )
+    val mainRecord = PrisonerHealth(
+      prisonerNumber = PRISONER_NUMBER,
+      foodAllergies = mutableSetOf(generateAllergy("FOOD_ALLERGY_EGG", PRISONER_NUMBER)),
+    )
+    save(mainRecord)
+    save(pendingRecord)
+
+    val result = repository.findAllPrisonersWithDietaryNeeds(mutableSetOf(PRISONER_NUMBER, pendingPrisonerNumber))
+    assertThat(result).hasSize(1)
+    assertThat(result[0].prisonerNumber).isEqualTo(PRISONER_NUMBER)
+    assertThat(result[0].pendingMerges).isEmpty()
+  }
+
+  @Test
+  fun `pendingMerges are loaded in batches`() {
+    // Create 30 prisoners. None of them have pending merges.
+    // 30 is > 25 (default batch size).
+    val mainPrisoners = (1..30).map { i ->
+      val prisonerNumber = "M%06d".format(i)
+      PrisonerHealth(prisonerNumber)
+    }
+    mainPrisoners.forEach { repository.save(it) }
+
+    TestTransaction.flagForCommit()
+    TestTransaction.end()
+    TestTransaction.start()
+    entityManager.clear()
+
+    val session = entityManager.unwrap(Session::class.java)
+    val statistics = session.sessionFactory.statistics
+    statistics.isStatisticsEnabled = true
+    statistics.clear()
+
+    // Load all main prisoners
+    val ids = (1..30).map { i -> "M%06d".format(i) }
+    val loadedMain = repository.findAllById(ids)
+    assertThat(loadedMain).hasSize(30)
+    val afterLoadCount = statistics.prepareStatementCount
+
+    // Access pendingMerges for each.
+    // Since there are no pending merges, this will only trigger the collection loads.
+    // With batching, this should be 2 queries (one for 25, one for 5).
+    loadedMain.forEach { it.pendingMerges.size }
+    val afterAccessCount = statistics.prepareStatementCount
+
+    val diff = afterAccessCount - afterLoadCount
+    // We expect 2 queries for pendingMerges if batching works.
+    // If not, we expect 30.
+    assertThat(diff).isEqualTo(2)
+  }
+
+  private fun createHealthWithAllergy(prisonerNumber: String, allergyId: String) = PrisonerHealth(
+    prisonerNumber = prisonerNumber,
+    foodAllergies = mutableSetOf(generateAllergy(allergyId, prisonerNumber)),
+  )
 
   private fun generateAllergy(id: String, prisonerNumber: String = PRISONER_NUMBER) = FoodAllergy(
     prisonerNumber = prisonerNumber,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/PrisonerHealthServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/PrisonerHealthServiceTest.kt
@@ -237,6 +237,78 @@ class PrisonerHealthServiceTest {
         ),
       )
     }
+
+    @Test
+    fun `filters out pending merges with no data`() {
+      val mainRecord = PrisonerHealth(PRISONER_NUMBER)
+      val pendingRecord = PrisonerHealth(PENDING_PRISONER_NUMBER)
+      pendingRecord.pendingMergeToPrisonerNumber = PRISONER_NUMBER
+      mainRecord.pendingMerges = mutableSetOf(pendingRecord)
+
+      whenever(prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(PRISONER_NUMBER)).thenReturn(mainRecord)
+
+      val result = underTest.getHealth(PRISONER_NUMBER)
+
+      assertThat(result).isNotNull
+      assertThat(result!!.pendingMerges).isEmpty()
+    }
+
+    @Test
+    fun `it fetches pending merges`() {
+      val mainPrisonerHealthRecord = PrisonerHealth(
+        prisonerNumber = PRISONER_NUMBER,
+        foodAllergies = mutableSetOf(FOOD_ALLERGY_OTHER),
+        pendingMerges = mutableSetOf(PENDING_PRISONER_HEALTH),
+      ).apply {
+        fieldMetadata[FOOD_ALLERGY] = FieldMetadata(PRISONER_NUMBER, FOOD_ALLERGY, NOW, USER1, PRISON_ID)
+      }
+
+      whenever(prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(PRISONER_NUMBER)).thenReturn(mainPrisonerHealthRecord)
+
+      val result = underTest.getHealth(PRISONER_NUMBER)
+
+      assertThat(result?.dietAndAllergy?.foodAllergies?.value).containsExactly(
+        ReferenceDataSelection(FOOD_ALLERGY_OTHER_CODE.toSimpleDto()),
+      )
+      assertThat(result?.pendingMerges).isEqualTo(
+        listOf(
+          HealthAndMedicationResponse(
+            dietAndAllergy = DietAndAllergyResponse(
+              foodAllergies = ValueWithMetadata(
+                listOf(ReferenceDataSelection(FOOD_ALLERGY_PEANUTS_CODE.toSimpleDto())),
+                NOW,
+                USER1,
+                PRISON_ID,
+              ),
+            ),
+          ),
+        ),
+      )
+      // Verify no recursion
+      assertThat(result?.pendingMerges?.first()?.pendingMerges).isEmpty()
+    }
+
+    @Test
+    fun `it handles identical data in main and pending records independently`() {
+      val mainPrisonerHealthRecord = PrisonerHealth(
+        prisonerNumber = PRISONER_NUMBER,
+        foodAllergies = mutableSetOf(FOOD_ALLERGY_PEANUTS),
+        pendingMerges = mutableSetOf(PENDING_PRISONER_HEALTH),
+      ).apply {
+        fieldMetadata[FOOD_ALLERGY] = FieldMetadata(PRISONER_NUMBER, FOOD_ALLERGY, NOW, USER1, PRISON_ID)
+      }
+
+      whenever(prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(PRISONER_NUMBER)).thenReturn(mainPrisonerHealthRecord)
+
+      val result = underTest.getHealth(PRISONER_NUMBER)
+
+      assertThat(result?.dietAndAllergy?.foodAllergies?.value).containsExactly(
+        ReferenceDataSelection(FOOD_ALLERGY_PEANUTS_CODE.toSimpleDto()),
+      )
+      assertThat(result?.pendingMerges?.first()?.dietAndAllergy?.foodAllergies?.value).containsExactly(
+        ReferenceDataSelection(FOOD_ALLERGY_PEANUTS_CODE.toSimpleDto()),
+      )
+    }
   }
 
   @Nested
@@ -671,6 +743,56 @@ class PrisonerHealthServiceTest {
             ),
           ),
         )
+      }
+
+      @Test
+      fun `Returns pending merges at the top level and avoids redundancy`() {
+        val pendingPrisoner = PRISONER_SEARCH_RESPONSE.copy(prisonerNumber = PENDING_PRISONER_NUMBER, lastName = "Pending")
+
+        val mainHealth = PrisonerHealth(
+          prisonerNumber = PRISONER_NUMBER,
+          foodAllergies = mutableSetOf(FOOD_ALLERGY_OTHER),
+          pendingMerges = mutableSetOf(PENDING_PRISONER_HEALTH),
+        ).apply {
+          fieldMetadata[FOOD_ALLERGY] = FieldMetadata(PRISONER_NUMBER, FOOD_ALLERGY, NOW, USER1, PRISON_ID)
+        }
+
+        whenever(prisonerSearchClient.getPrisonersForPrison(PRISON_ID)).thenReturn(listOf(PRISONER_SEARCH_RESPONSE, pendingPrisoner))
+        whenever(prisonerHealthRepository.findAllPrisonersWithDietaryNeeds(any())).thenReturn(listOf(mainHealth))
+
+        val result = underTest.getHealthForPrison(PRISON_ID, HealthAndMedicationForPrisonRequest(1, 10))
+
+        assertThat(result?.content).hasSize(1)
+        val dto = result?.content?.first()!!
+        assertThat(dto.prisonerNumber).isEqualTo(PRISONER_NUMBER)
+        // Redundancy check: nested health should NOT have pendingMerges
+        assertThat(dto.health.pendingMerges).isEmpty()
+        // Top level pendingMerges should be present
+        assertThat(dto.pendingMerges).hasSize(1)
+        assertThat(dto.pendingMerges.first().prisonerNumber).isEqualTo(PENDING_PRISONER_NUMBER)
+        // Nested ones should also NOT have pendingMerges in their health object
+        assertThat(dto.pendingMerges.first().health.pendingMerges).isEmpty()
+      }
+
+      @Test
+      fun `it returns top-level blank records if they have data-populated pending merges`() {
+        val pendingPrisoner = PRISONER_SEARCH_RESPONSE.copy(prisonerNumber = PENDING_PRISONER_NUMBER, lastName = "Pending")
+
+        val mainHealth = PrisonerHealth(
+          prisonerNumber = PRISONER_NUMBER,
+          pendingMerges = mutableSetOf(PENDING_PRISONER_HEALTH),
+        )
+
+        whenever(prisonerSearchClient.getPrisonersForPrison(PRISON_ID)).thenReturn(listOf(PRISONER_SEARCH_RESPONSE, pendingPrisoner))
+        whenever(prisonerHealthRepository.findAllPrisonersWithDietaryNeeds(any())).thenReturn(listOf(mainHealth))
+
+        val result = underTest.getHealthForPrison(PRISON_ID, HealthAndMedicationForPrisonRequest(1, 10))
+
+        assertThat(result?.content).hasSize(1)
+        val dto = result?.content?.first()!!
+        assertThat(dto.prisonerNumber).isEqualTo(PRISONER_NUMBER)
+        assertThat(dto.health.dietAndAllergy?.foodAllergies).isNull()
+        assertThat(dto.pendingMerges).hasSize(1)
       }
 
       @Nested
@@ -1336,6 +1458,7 @@ class PrisonerHealthServiceTest {
   private companion object {
     const val PRISON_ID = "STI"
     const val PRISONER_NUMBER = "A1234AA"
+    const val PENDING_PRISONER_NUMBER = "B1234BB"
     const val PRISONER_FIRST_NAME = "First"
     const val PRISONER_LAST_NAME = "Last"
     const val PRISONER_SEARCH_LOCATION = "Recp"
@@ -1465,30 +1588,21 @@ class PrisonerHealthServiceTest {
 
     val PRISONER_HEALTH = PrisonerHealth(
       prisonerNumber = PRISONER_NUMBER,
-      medicalDietaryRequirements = mutableSetOf(
-        MEDICAL_DIET_COELIAC,
-      ),
-      foodAllergies = mutableSetOf(
-        FOOD_ALLERGY_PEANUTS,
-      ),
-      fieldMetadata = mutableMapOf(
-        MEDICAL_DIET to FieldMetadata(
-          PRISONER_NUMBER,
-          MEDICAL_DIET,
-          NOW,
-          USER1,
-          PRISON_ID,
-        ),
-        FOOD_ALLERGY to FieldMetadata(
-          PRISONER_NUMBER,
-          MEDICAL_DIET,
-          NOW,
-          USER1,
-          PRISON_ID,
-        ),
-      ),
+      foodAllergies = mutableSetOf(FOOD_ALLERGY_PEANUTS),
+      medicalDietaryRequirements = mutableSetOf(MEDICAL_DIET_COELIAC),
       location = PRISONER_LOCATION,
-    )
+    ).apply {
+      fieldMetadata[FOOD_ALLERGY] = FieldMetadata(PRISONER_NUMBER, FOOD_ALLERGY, NOW, USER1, PRISON_ID)
+      fieldMetadata[MEDICAL_DIET] = FieldMetadata(PRISONER_NUMBER, MEDICAL_DIET, NOW, USER1, PRISON_ID)
+    }
+
+    val PENDING_PRISONER_HEALTH = PrisonerHealth(
+      prisonerNumber = PENDING_PRISONER_NUMBER,
+      foodAllergies = mutableSetOf(FoodAllergy(PENDING_PRISONER_NUMBER, FOOD_ALLERGY_PEANUTS_CODE)),
+    ).apply {
+      pendingMergeToPrisonerNumber = PRISONER_NUMBER
+      fieldMetadata[FOOD_ALLERGY] = FieldMetadata(PENDING_PRISONER_NUMBER, FOOD_ALLERGY, NOW, USER1, PRISON_ID)
+    }
 
     @JvmStatic
     fun singleHealthAndMedicationFilters(): Stream<Arguments> = Stream.of(

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -33,7 +33,7 @@ hmpps:
   sar:
     tests:
       attachments-expected: false
-      expected-flyway-schema-version: 21
+      expected-flyway-schema-version: 22
       expected-jpa-entity-schema:
         path: /sar/entity-schema.json
       expected-api-response:

--- a/src/test/resources/sar/entity-schema.json
+++ b/src/test/resources/sar/entity-schema.json
@@ -52,6 +52,8 @@
     "foodAllergies": "Set",
     "location": "PrisonerLocation",
     "medicalDietaryRequirements": "Set",
+    "pendingMergeToPrisonerNumber": "String",
+    "pendingMerges": "Set",
     "personalisedDietaryRequirements": "Set",
     "prisonerNumber": "String"
   },


### PR DESCRIPTION
- Added `pending_merge_to_prisoner_number` to the health table with an explicit partial index
- Updated PrisonerHealth to include `pendingMergeToPrisonerNumber` field and a `@OneToMany` relationship in the form of a collection (`pendingMerges`)
- Applied `@BatchSize(size = 25)` (same as the max page results in the diet and allergy UI) to the `pendingMerges` collection to prevent N+1 query issues in the list view
- Enhanced repo methods `findAllPrisonersWithDietaryNeeds` and `findAllPrisonersWithoutLocationData` to include the prime/head records that have active (not soft-deleted) pending merges
- Updated `HealthAndMedicationResponse` and `HealthAndMedicationForPrisonDto` to surface the `pendingMerges` data
- Implemented filtering in `toHealthDto` and the service layer to ensure that pending merges are only returned if they contain actual diet or allergy data
- Added service-layer integration tests to verify that empty pending merges are correctly filtered out
- Added a repo-layer performance test for the batching