### PR TITLE
CDPS-2000 Add a PUT endpoint to complete a pending merge (metadata only)

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/resource/HealthAndMedicationResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/resource/HealthAndMedicationResource.kt
@@ -179,4 +179,55 @@ class HealthAndMedicationResource(private val prisonerHealthService: PrisonerHea
   ) {
     prisonerHealthService.updateSmokerStatus(prisonerNumber, request)
   }
+
+  @PutMapping("/merge-completion")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @PreAuthorize("hasRole('ROLE_HEALTH_AND_MEDICATION_API__HEALTH_AND_MEDICATION_DATA__RW')")
+  @Operation(
+    summary = "Indicates that a pending merge should be considered complete",
+    description = "Requires role `ROLE_HEALTH_AND_MEDICATION_API__HEALTH_AND_MEDICATION_DATA__RW`",
+    responses = [
+      ApiResponse(
+        responseCode = "204",
+        description = "No content",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires ROLE_HEALTH_AND_MEDICATION_API__HEALTH_AND_MEDICATION_DATA__RW",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Data not found",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  fun completeMerge(
+    @Schema(description = "The prisoner number", example = "A1234AA", required = true)
+    @PathVariable
+    prisonerNumber: String,
+  ) {
+    prisonerHealthService.completeMerge(prisonerNumber)
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/PrisonerHealthService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/PrisonerHealthService.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.healthandmedication.client.prisonapi.PrisonA
 import uk.gov.justice.digital.hmpps.healthandmedication.client.prisonapi.request.PrisonApiSmokerStatus
 import uk.gov.justice.digital.hmpps.healthandmedication.client.prisonapi.request.PrisonApiSmokerStatusUpdate
 import uk.gov.justice.digital.hmpps.healthandmedication.client.prisonersearch.PrisonerSearchClient
+import uk.gov.justice.digital.hmpps.healthandmedication.config.HealthAndMedicationDataNotFoundException
 import uk.gov.justice.digital.hmpps.healthandmedication.enums.HealthAndMedicationField
 import uk.gov.justice.digital.hmpps.healthandmedication.jpa.CateringInstructions
 import uk.gov.justice.digital.hmpps.healthandmedication.jpa.FoodAllergy
@@ -251,6 +252,28 @@ class PrisonerHealthService(
 
   fun updateSmokerStatus(prisonerNumber: String, request: UpdateSmokerStatusRequest) {
     prisonApiClient.updateSmokerStatus(prisonerNumber, request.convertToPrisonApiRequest())
+  }
+
+  @Transactional
+  fun completeMerge(prisonerNumber: String) {
+    val now = ZonedDateTime.now(clock)
+    val user = authenticationFacade.getUserOrSystemInContext()
+    val parent = prisonerHealthRepository.findByPrisonerNumberAndDeletedAtIsNull(prisonerNumber)
+      ?: throw HealthAndMedicationDataNotFoundException(prisonerNumber)
+
+    parent.pendingMerges.forEach { child ->
+      child.fieldHistory.forEach { history ->
+        history.prisonerNumber = parent.prisonerNumber
+        history.mergedAt = now
+        history.mergedFrom = child.prisonerNumber
+      }
+      child.pendingMergeToPrisonerNumber = null
+      child.deletedAt = now
+      child.deletedBy = user
+      child.deletionReason = "Merged into ${parent.prisonerNumber}"
+
+      prisonerHealthRepository.save(child)
+    }
   }
 
   private fun matchesFilters(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/event/PrisonerMergedIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/event/PrisonerMergedIntTest.kt
@@ -7,19 +7,35 @@ import org.awaitility.kotlin.untilCallTo
 import org.awaitility.kotlin.withPollDelay
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.transaction.TestTransaction
+import org.springframework.test.web.reactive.server.expectBody
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.healthandmedication.enums.HealthAndMedicationField.FOOD_ALLERGY
 import uk.gov.justice.digital.hmpps.healthandmedication.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.healthandmedication.integration.wiremock.PRISONER_NUMBER
+import uk.gov.justice.digital.hmpps.healthandmedication.jpa.FieldHistory
+import uk.gov.justice.digital.hmpps.healthandmedication.jpa.FoodAllergy
+import uk.gov.justice.digital.hmpps.healthandmedication.jpa.PrisonerHealth
+import uk.gov.justice.digital.hmpps.healthandmedication.jpa.repository.ReferenceDataCodeRepository
 import uk.gov.justice.digital.hmpps.healthandmedication.jpa.repository.utils.RepopulateDb
+import uk.gov.justice.digital.hmpps.healthandmedication.resource.dto.response.HealthAndMedicationResponse
 import uk.gov.justice.digital.hmpps.healthandmedication.service.event.DomainEventsListener.Companion.PRISONER_MERGED
 import uk.gov.justice.digital.hmpps.healthandmedication.service.event.PersonReference.Companion.withPrisonNumber
+import uk.gov.justice.digital.hmpps.healthandmedication.utils.toReferenceDataCode
 import java.time.Duration.ofSeconds
 import java.time.ZonedDateTime
 
 class PrisonerMergedIntTest : IntegrationTestBase() {
 
+  @Autowired
+  lateinit var referenceDataCodeRepository: ReferenceDataCodeRepository
+
   companion object {
     private const val PRISONER_NUMBER_NOT_FOUND = "Z9999ZZ"
+    private const val PARENT_PRISONER_NUMBER = "A1234AA"
+    private const val CHILD_PRISONER_NUMBER = "B1234BB"
+    private const val USER1 = "USER1"
   }
 
   @Disabled("Merge handling not yet implemented")
@@ -55,6 +71,103 @@ class PrisonerMergedIntTest : IntegrationTestBase() {
     assertThat(fieldMetadataRepository.findAllByPrisonerNumber(PRISONER_NUMBER)).isEmpty()
     assertThat(fieldHistoryRepository.findAllByPrisonerNumber(PRISONER_NUMBER)).isEmpty()
     assertThat(prisonerLocationRepository.findByPrisonerNumber(PRISONER_NUMBER)).isNull()
+  }
+
+  @Test
+  @Transactional
+  @RepopulateDb
+  fun `manual merge should soft-delete child record`() {
+    // set up two entities: a parent record and a linked child record
+    val peanuts = toReferenceDataCode(referenceDataCodeRepository, "FOOD_ALLERGY_PEANUTS")!!
+
+    val parent = PrisonerHealth(PARENT_PRISONER_NUMBER)
+    prisonerHealthRepository.save(parent)
+
+    val child = PrisonerHealth(CHILD_PRISONER_NUMBER).apply {
+      pendingMergeToPrisonerNumber = PARENT_PRISONER_NUMBER
+      foodAllergies = mutableSetOf(FoodAllergy(CHILD_PRISONER_NUMBER, peanuts))
+    }
+    prisonerHealthRepository.save(child)
+
+    TestTransaction.flagForCommit()
+    TestTransaction.end()
+
+    // initiate merge (currently only deals with field history & metadata)
+    webTestClient.put().uri("/prisoners/$PARENT_PRISONER_NUMBER/merge-completion")
+      .headers(setAuthorisation(roles = listOf("ROLE_HEALTH_AND_MEDICATION_API__HEALTH_AND_MEDICATION_DATA__RW")))
+      .exchange()
+      .expectStatus().isNoContent
+
+    // child record is soft-deleted and 404s
+    webTestClient.get().uri("/prisoners/$CHILD_PRISONER_NUMBER")
+      .headers(setAuthorisation(roles = listOf("ROLE_HEALTH_AND_MEDICATION_API__HEALTH_AND_MEDICATION_DATA__RO")))
+      .exchange()
+      .expectStatus().isNotFound
+
+    TestTransaction.start()
+
+    // soft-deleted child still exists with the same information (for manual restoration purposes)
+    val softDeletedChild = prisonerHealthRepository.findById(CHILD_PRISONER_NUMBER).get()
+    assertThat(softDeletedChild.pendingMergeToPrisonerNumber).isNull()
+    assertThat(softDeletedChild.deletedAt).isEqualTo(ZonedDateTime.now(clock))
+    assertThat(softDeletedChild.deletionReason).isEqualTo("Merged into $PARENT_PRISONER_NUMBER")
+    assertThat(softDeletedChild.foodAllergies).contains(FoodAllergy(CHILD_PRISONER_NUMBER, peanuts))
+
+    // parent's pending merge list is empty
+    webTestClient.get().uri("/prisoners/$PARENT_PRISONER_NUMBER")
+      .headers(setAuthorisation(roles = listOf("ROLE_HEALTH_AND_MEDICATION_API__HEALTH_AND_MEDICATION_DATA__RO")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody<HealthAndMedicationResponse>()
+      .returnResult().responseBody!!.pendingMerges.isEmpty()
+
+    TestTransaction.end()
+  }
+
+  @Test
+  @Transactional
+  @RepopulateDb
+  fun `manual merge should transfer field history from child record to parent record`() {
+    // set up two entities: a parent record and a linked child record
+    val peanuts = toReferenceDataCode(referenceDataCodeRepository, "FOOD_ALLERGY_PEANUTS")!!
+
+    val parent = PrisonerHealth(PARENT_PRISONER_NUMBER)
+    prisonerHealthRepository.save(parent)
+
+    val child = PrisonerHealth(CHILD_PRISONER_NUMBER).apply {
+      pendingMergeToPrisonerNumber = PARENT_PRISONER_NUMBER
+      fieldHistory.add(
+        FieldHistory(
+          prisonerNumber = CHILD_PRISONER_NUMBER,
+          field = FOOD_ALLERGY,
+          valueRef = peanuts,
+          createdBy = USER1,
+          prisonId = "MDI",
+          createdAt = ZonedDateTime.now(clock).minusDays(1),
+        ),
+      )
+    }
+    prisonerHealthRepository.save(child)
+
+    // Commit changes so webTestClient can see them
+    TestTransaction.flagForCommit()
+    TestTransaction.end()
+
+    // initiate merge (currently only deals with field history & metadata)
+    webTestClient.put().uri("/prisoners/$PARENT_PRISONER_NUMBER/merge-completion")
+      .headers(setAuthorisation(roles = listOf("ROLE_HEALTH_AND_MEDICATION_API__HEALTH_AND_MEDICATION_DATA__RW")))
+      .exchange()
+      .expectStatus().isNoContent
+
+    // Restart transaction to check DB
+    TestTransaction.start()
+    // check that the child record's field history has been copied across to the parent record
+    val parentHistory = fieldHistoryRepository.findAllByPrisonerNumber(PARENT_PRISONER_NUMBER)
+    val transferredHistory = parentHistory.find { it.field == FOOD_ALLERGY && it.mergedFrom == CHILD_PRISONER_NUMBER }
+    assertThat(transferredHistory).isNotNull()
+    assertThat(transferredHistory?.prisonerNumber).isEqualTo(PARENT_PRISONER_NUMBER)
+    assertThat(transferredHistory?.mergedAt).isEqualTo(ZonedDateTime.now(clock))
+    assertThat(transferredHistory?.valueRef).isEqualTo(peanuts)
   }
 
   private fun personMergedEvent(


### PR DESCRIPTION
- added PUT in `HealthAndMedicationResource` at `/prisoners/{prisonerNumber}/merge-completion` to allow catering staff to manually confirm and finish a pending prisoner merge
- added `completeMerge` to `PrisonerHealthService` which copies all `FieldHistory` items from the child to the parent record, clears the `pendingMerge` list from the parent record, and soft-deletes the child record
- added two integration tests to confirm soft-deletion & field history migration in the event of a manual merge