### PR TITLE
CDPS-2032 Add additional ordering to push pending merge records to the top of the results

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/resource/dto/request/HealthAndMedicationForPrisonRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/resource/dto/request/HealthAndMedicationForPrisonRequest.kt
@@ -39,6 +39,9 @@ data class HealthAndMedicationForPrisonRequest(
       "filter, but do not need to match all filters (i.e. filters are applied using OR logic)",
   )
   val filters: HealthAndMedicationRequestFilters? = null,
+
+  @Parameter(description = "Whether to push records with pending merges to the top of the results", example = "true")
+  val surfaceRecordsPendingMerge: Boolean = false,
 ) : PagedRequest
 
 data class HealthAndMedicationRequestFilters(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/resource/dto/response/HealthAndMedicationForPrisonResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/resource/dto/response/HealthAndMedicationForPrisonResponse.kt
@@ -14,4 +14,5 @@ data class HealthAndMedicationForPrisonDto(
 data class HealthAndMedicationForPrisonResponse(
   val content: List<HealthAndMedicationForPrisonDto>,
   val metadata: PageMeta,
+  val containsRecordsPendingMerge: Boolean = false,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/PrisonerHealthService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/PrisonerHealthService.kt
@@ -119,7 +119,19 @@ class PrisonerHealthService(
             )
           }
 
-      val (content, metadata) = Pagination.paginateCollection(request.page, request.size, healthForPrison)
+      // If any pending merges exist, we set a flag regardless of how we then sort results
+      val containsRecordsPendingMerge = healthForPrison.any { it.pendingMerges.isNotEmpty() }
+
+      // Push any pending merges to the top of the list (in page view only), preserving original ordering
+      val resultsToPaginate = if (request.surfaceRecordsPendingMerge) {
+        val (pending, others) = healthForPrison.partition { it.pendingMerges.isNotEmpty() }
+        pending + others
+      } else {
+        healthForPrison
+      }
+
+      // Paginate results
+      val (content, metadata) = Pagination.paginateCollection(request.page, request.size, resultsToPaginate)
 
       return HealthAndMedicationForPrisonResponse(
         content = content,
@@ -134,6 +146,7 @@ class PrisonerHealthService(
           totalElements = metadata.totalElements,
           totalPages = metadata.totalPages,
         ),
+        containsRecordsPendingMerge = containsRecordsPendingMerge,
       )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/PrisonerHealthServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/service/PrisonerHealthServiceTest.kt
@@ -1015,6 +1015,46 @@ class PrisonerHealthServiceTest {
         }
       }
     }
+
+    @Nested
+    inner class PendingMergeSurfacing {
+      @Test
+      fun `it pushes records with pending merges to the top and identifies presence of pending merges`() {
+        val prisonerA = PrisonerDto(PRISONER_NUMBER, PRISON_ID)
+        val prisonerC = PrisonerDto("C1234CC", PRISON_ID)
+        // arbitrary natural order: C then A
+        whenever(prisonerSearchClient.getPrisonersForPrison(PRISON_ID)).thenReturn(listOf(prisonerC, prisonerA))
+
+        // A has a pending record to it (B)
+        // C is a lone record
+        val healthA = PrisonerHealth(PRISONER_NUMBER).apply {
+          pendingMerges = mutableSetOf(
+            PrisonerHealth(PENDING_PRISONER_NUMBER).apply {
+              foodAllergies = mutableSetOf(FoodAllergy(PENDING_PRISONER_NUMBER, FOOD_ALLERGY_PEANUTS_CODE))
+            },
+          )
+        }
+        val healthC = PrisonerHealth("C1234CC")
+        whenever(prisonerHealthRepository.findAllPrisonersWithDietaryNeeds(mutableListOf("C1234CC", PRISONER_NUMBER)))
+          .thenReturn(listOf(healthC, healthA))
+
+        // surfacing enabled (page view) - A should be pushed to the top because it has a pending merge
+        val surfacedResponse = underTest.getHealthForPrison(PRISON_ID, HealthAndMedicationForPrisonRequest(1, 10, surfaceRecordsPendingMerge = true))
+        val firstRecord = surfacedResponse!!.content.first()
+        assertThat(firstRecord.prisonerNumber).isEqualTo(PRISONER_NUMBER)
+        assertThat(firstRecord.pendingMerges.first().prisonerNumber).isEqualTo(PENDING_PRISONER_NUMBER)
+        assertThat(surfacedResponse.content.last().prisonerNumber).isEqualTo("C1234CC")
+        assertThat(surfacedResponse.containsRecordsPendingMerge).isTrue()
+
+        // surfacing disabled (print view) - should maintain natural order (C then A)
+        val defaultResponse = underTest.getHealthForPrison(PRISON_ID, HealthAndMedicationForPrisonRequest(1, 10, surfaceRecordsPendingMerge = false))
+        assertThat(defaultResponse!!.content.first().prisonerNumber).isEqualTo("C1234CC")
+        val lastRecord = defaultResponse.content.last()
+        assertThat(lastRecord.prisonerNumber).isEqualTo(PRISONER_NUMBER)
+        assertThat(lastRecord.pendingMerges.first().prisonerNumber).isEqualTo(PENDING_PRISONER_NUMBER)
+        assertThat(defaultResponse.containsRecordsPendingMerge).isTrue()
+      }
+    }
   }
 
   @Nested


### PR DESCRIPTION
- adds fucntionality to push records with pending merges to the top of the result list
- otherwise preserves all other sorting as-is, pre-pagination
- controlled by `surfaceRecordsPendingMerge` passed to `HealthAndMedicationForPrisonRequest`
- also adds `containsRecordsPendingMerge` to `HealthAndMedicationForPrisonResponse` to expose the boolean to the UI (which will show a banner to the user)
- unit-testing at service layer only, for now