### PR TITLE
CDPS-2009: Add SchemaSpy report generation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,10 @@ updates:
       - "*"
     cooldown:
       default-days: 7
+    ignore:
+      - dependency-name: "localstack/localstack"
+        versions:
+          - ">4"
   - package-ecosystem: "github-actions"
     multi-ecosystem-group: "infrastructure"
     directory: "/"

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -20,6 +20,7 @@ on:
 permissions:
   contents: read
   packages: write
+  pages: write
   id-token: write
   attestations: write
 
@@ -52,6 +53,20 @@ jobs:
       postgres-db: 'health-and-medication-data'
       postgres-username: 'health-and-medication-data'
       postgres-password: 'health-and-medication-data'
+
+  schema-spy:
+    name: SchemaSpy report
+    if: github.ref == 'refs/heads/main'
+    needs:
+      - gradle-verify
+    uses: ./.github/workflows/schema-spy.yml
+    with:
+      docker_compose_file: 'docker-compose-schema-spy.yml'
+      init_db_cli: './gradlew initialiseDatabase'
+      database_name: 'health-and-medication-data'
+      database_user: 'health-and-medication-data'
+      database_password: 'health-and-medication-data'
+    secrets: inherit
 
   build:
     name: Build docker image from hmpps-github-actions

--- a/.github/workflows/schema-spy.yml
+++ b/.github/workflows/schema-spy.yml
@@ -1,0 +1,107 @@
+name: SchemaSpy report
+
+on:
+  workflow_call:
+    inputs:
+      java_version:
+        description: Java version
+        type: string
+        default: '25'
+      java_options:
+        description: Java options
+        type: string
+        default: '-Xmx512m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process'
+      schemaspy_version:
+        description: SchemaSpy version
+        type: string
+        default: '7.0.2'
+      postgres_driver_version:
+        description: Postgres version
+        type: string
+        default: '42.7.13'
+      exclude:
+        description: Regex of tables to be excluded
+        type: string
+        default: 'flyway_schema_history'
+      docker_compose_file:
+        description: Path to Docker Compose file to start localstack and postgres containers
+        type: string
+        required: true
+      init_db_cli:
+        description: Command line to initialise database
+        type: string
+        default: './gradlew check'
+      database_name:
+        description: Database name
+        type: string
+        required: true
+      database_user:
+        description: Database user name
+        type: string
+        required: true
+      database_password:
+        description: Database user password
+        type: string
+        required: true
+      database_schema:
+        description: Database schema name
+        type: string
+        default: public
+
+jobs:
+  schema-spy:
+    name: Generate SchemaSpy report
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    timeout-minutes: 240
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Refresh cache
+        id: initial-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        env:
+          cache-name: kotlin-cache
+        with:
+          path: |
+            - gradle-{{ checksum "build.gradle.kts" }}
+            - gradle-
+          key: ${{ runner.os }}-gradle-${{ env.cache-name }}-${{ hashFiles('build.gradle.kts') }}
+
+      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+        with:
+          distribution: 'temurin'
+          java-version: '${{ inputs.java_version }}'
+          cache: 'gradle'
+          cache-dependency-path: |
+            *.gradle*
+            **/gradle-wrapper.properties
+
+      - name: Initialise database and generate SchemaSpy report
+        shell: bash
+        run: |
+          docker compose -f ${{ inputs.docker_compose_file }} up -d
+          curl -L https://github.com/schemaspy/schemaspy/releases/download/v${{ inputs.schemaspy_version }}/schemaspy-app.jar --output /tmp/schemaspy.jar
+          curl -L https://jdbc.postgresql.org/download/postgresql-${{ inputs.postgres_driver_version }}.jar --output /tmp/postgres-driver.jar
+          export JAVA_OPTS="${{ inputs.java_options }}"
+          ${{ inputs.init_db_cli }}
+          java -jar /tmp/schemaspy.jar -t pgsql -dp /tmp/postgres-driver.jar -db ${{ inputs.database_name }} -host localhost -port 5432 -s ${{ inputs.database_schema }} -vizjs -u ${{ inputs.database_user }} -p ${{ inputs.database_password }} -I ${{ inputs.exclude }} -norows -o /tmp/schema-spy-report
+
+      - name: Setup GitHub Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Publish HTML report
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: /tmp/schema-spy-report/
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+
+      - name: Link workflow summary to report
+        shell: bash
+        run: |
+          echo '[SchemaSpy report]('https://$GITHUB_REPOSITORY_OWNER.github.io/$(basename $GITHUB_REPOSITORY)'/)' >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Pipeline [test -> build -> deploy]](https://github.com/ministryofjustice/hmpps-health-and-medication-api/actions/workflows/pipeline.yml/badge.svg?branch=main)](https://github.com/ministryofjustice/hmpps-health-and-medication-api/actions/workflows/pipeline.yml)
 [![API docs](https://img.shields.io/badge/API_docs_-view-85EA2D.svg?logo=swagger)](https://health-and-medication-api-dev.hmpps.service.justice.gov.uk/swagger-ui/index.html)
 [![Event docs](https://img.shields.io/badge/Event_docs-view-85EA2D.svg)](https://studio.asyncapi.com/?readOnly&url=https://raw.githubusercontent.com/ministryofjustice/hmpps-health-and-medication-api/async-api.yml)
+[![Database schema](https://img.shields.io/badge/Database_schema-view-85EA2D.svg)](https://ministryofjustice.github.io/hmpps-health-and-medication-api/)
 
 This is a Spring Boot service, written in Kotlin, which owns health and medication data about a person in prison.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -71,6 +73,22 @@ tasks {
     compilerOptions {
       jvmTarget = JvmTarget.JVM_25
     }
+  }
+
+  test {
+    exclude("**/InitialiseDatabase.class")
+  }
+
+  val testSuite = testing.suites.named("test", JvmTestSuite::class)
+  register("initialiseDatabase", Test::class) {
+    description = "initialise database"
+    testClassesDirs = files(testSuite.map { it.sources.output.classesDirs })
+    classpath = files(testSuite.map { it.sources.runtimeClasspath })
+    include("**/InitialiseDatabase.class")
+  }
+
+  getByName("initialiseDatabase") {
+    onlyIf { gradle.startParameter.taskNames.contains("initialiseDatabase") }
   }
 }
 

--- a/docker-compose-schema-spy.yml
+++ b/docker-compose-schema-spy.yml
@@ -1,0 +1,30 @@
+services:
+  db:
+    image: postgres:18
+    networks:
+      - hmpps
+    container_name: postgres
+    restart: always
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_DB=health-and-medication-data
+      - POSTGRES_PASSWORD=health-and-medication-data
+      - POSTGRES_USER=health-and-medication-data
+
+  localstack:
+    image: localstack/localstack:4
+    networks:
+      - hmpps
+    container_name: localstack
+    ports:
+      - "4566:4566"
+    environment:
+      - SERVICES=sqs,sns
+      - DEBUG=${DEBUG-}
+      - DOCKER_HOST=unix:///var/run/docker.sock
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+
+networks:
+  hmpps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - TZ="Europe/London"
 
   localstack:
-    image: localstack/localstack:2026.6.2
+    image: localstack/localstack:4
     networks:
       - hmpps
     container_name: localstack

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/integration/InitialiseDatabase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/healthandmedication/integration/InitialiseDatabase.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.healthandmedication.integration
+
+import org.junit.jupiter.api.Test
+
+class InitialiseDatabase : IntegrationTestBase() {
+  @Test
+  fun `initialises database`() {
+    println("Database has been initialised by IntegrationTestBase")
+  }
+}


### PR DESCRIPTION
- normalise SchemaSpy report generation config between CDPS api repositories
- pin localstack image tag to 4 since newer versions require a licence